### PR TITLE
fix: Check for player data on resource start

### DIFF
--- a/client/framework/qb.lua
+++ b/client/framework/qb.lua
@@ -26,7 +26,7 @@ if usingOxInventory then
     AddEventHandler('ox_inventory:itemCount', function(name, count)
         playerItems[name] = count
     end)
-elseif playerData then
+elseif next(playerData) then
     setPlayerItems()
 end
 


### PR DESCRIPTION
Fixes #29 

will then load the items in the `QBCore:Client:OnPlayerLoaded` event. Loaded on my dev server and had no issues