### PR TITLE
tweak(compat/qb-target): explicitly get vec3

### DIFF
--- a/client/compat/qb-target.lua
+++ b/client/compat/qb-target.lua
@@ -118,7 +118,7 @@ end
 exportHandler('AddBoxZone', function(name, center, length, width, options, targetoptions)
     return lib.zones.box({
         name = name,
-        coords = center,
+        coords = center.xyz,
         size = vec3(width, length, (options.useZ or not options.maxZ) and center.z or math.abs(options.maxZ - options.minZ)),
         debug = options.debugPoly,
         rotation = options.heading,
@@ -149,7 +149,7 @@ end)
 exportHandler('AddCircleZone', function(name, center, radius, options, targetoptions)
     return lib.zones.sphere({
         name = name,
-        coords = center,
+        coords = center.xyz,
         radius = radius,
         debug = options.debugPoly,
         options = convert(targetoptions),


### PR DESCRIPTION
This change converts zones that were given a vector4 value to the proper expected vector3 value in lib, as a compatibility change. Previously qb-target didn't care for vec4 or vec3.