### PR TITLE
fix(compact): check if job is "all"

### DIFF
--- a/client/compat/qb-target.lua
+++ b/client/compat/qb-target.lua
@@ -16,6 +16,10 @@ local function convert(options)
         v.name = v.name or v.label
         v.items = v.item
         v.groups = v.job
+        
+        if v.groups == "all" then
+            v.groups = nil
+        end
 
         local groupType = type(v.groups)
         if groupType == 'nil' then

--- a/client/compat/qtarget.lua
+++ b/client/compat/qtarget.lua
@@ -15,6 +15,9 @@ local function convert(options)
         v.distance = v.distance or distance
         v.name = v.name or v.label
         v.groups = v.job
+        if v.groups == "all" then
+            v.groups = nil
+        end
         v.items = v.item or v.required_item
 
         if v.event and v.type and v.type ~= 'client' then


### PR DESCRIPTION
I was testing compatibily with qtarget exports. I came across export where job = "all". It did not work, so I came with this solution