### PR TITLE
Update qb.lua

### DIFF
--- a/client/framework/qb.lua
+++ b/client/framework/qb.lua
@@ -84,7 +84,9 @@ function PlayerHasItems(filter)
     local _type = type(filter)
 
     if _type == 'string' then
-        if playerItems[filter] < 1 then return end
+          if type(playerItems[filter]) == 'number' then
+            if playerItems[filter] < 1 then return end
+        end
     elseif _type == 'table' then
         local tabletype = table.type(filter)
 


### PR DESCRIPTION
PlayerHasItemf function for qb sends 2 arg (table and number). Which causes an error because it is trying to compare a table to a number. Added a filter to only compare the number and not the table.