### PR TITLE
Allow a new target option to configure whether all items should be required

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -148,8 +148,37 @@ local function enableTargeting()
                         hide = true
                     end
 
-                    if option.items and not PlayerHasItems(option.items) then
-                        hide = true
+                    if option.items then
+                        local _type = type(option.items)
+
+                        if option.itemsAny and _type ~= "string" then
+                            if _type == "table" then
+                                local _h = true
+                                local _tableType = table.type(option.items)
+
+                                if _tableType == "hash" then
+                                    for name, amount in pairs(option.items) do
+                                        if PlayerHasItems({[name] = amount}) then
+                                            _h = false
+                                            break
+                                        end
+                                    end
+                                elseif _tableType == "array" then
+                                    for i = 1, #option.items do
+                                        if PlayerHasItems(option.items[i]) then
+                                            _h = false
+                                            break
+                                        end
+                                    end
+                                end
+
+                                hide = _h
+                            end
+                        else
+                            if not PlayerHasItems(option.items) then
+                                hide = true
+                            end
+                        end
                     end
 
                     local bone = option.bones


### PR DESCRIPTION
Adds a new option when creating a target: 'itemsAny? = bool`. If itemsAny is set to true, the "items" option will be joined with an or statement rather than an and statement, meaning that the items option will be treated like an "array of items, where at least one of the items is required to show the option".

This gives developers the option to, for instance - allow using one of multiple items to slash a tire.