### PR TITLE
Fix for click event not working for some players

### DIFF
--- a/web/js/createOptions.js
+++ b/web/js/createOptions.js
@@ -11,6 +11,6 @@ export function createOptions(type, data, id) {
       <i class="fa-fw ${data.icon} option-icon" style="color:${data.iconColor || '#cfd2da'}"></i>
       <p class="option-label">${data.label}</p>
     `;
-  option.addEventListener('click', () => fetchNui('select', [type, id]));
+  option.addEventListener('mousedown', () => fetchNui('select', [type, id]));
   optionsWrapper.appendChild(option);
 }


### PR DESCRIPTION
- Changed the 'click' event to 'mousedown' as a small percentage of computers do not respond to the click event for whatever reason.