### PR TITLE
Fixed a zone deletion error

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -28,7 +28,9 @@ end
 
 ---@param id number
 function target.removeZone(id)
-    Zones[id]:remove()
+    if Zones[id] ~= nil then
+        Zones[id]:remove()
+    end
 end
 
 ---@param target table


### PR DESCRIPTION
When we delete a non-existent zone it returns a console error rather than checking if the zone exists or not.