### PR TITLE
Missing exportHandlers and AddBoxZone conditions

### DIFF
--- a/client/compat/qb-target.lua
+++ b/client/compat/qb-target.lua
@@ -133,7 +133,11 @@ exportHandler('AddBoxZone', function(name, center, length, width, options, targe
     local z = center.z
 
     if not options.useZ then
-        z = z + math.abs(options.maxZ - options.minZ) / 2
+        if options.maxZ == nil or options.minZ == nil then
+            z = z
+        else
+            z = z + math.abs(options.maxZ - options.minZ) / 2
+        end
         center = vec3(center.x, center.y, z)
     end
 
@@ -161,6 +165,20 @@ exportHandler('AddPolyZone', function(name, points, options, targetoptions)
         name = name,
         points = newPoints,
         thickness = thickness,
+        debug = options.debugPoly,
+        options = convert(targetoptions),
+        resource = GetInvokingResource(),
+    }).id
+end)
+
+exportHandler('AddEntityZone', function(name, entity, radius, options, targetoptions)
+    local center = GetEntityCoords(entity)
+    local radius = radius or 1
+
+    return lib.zones.sphere({
+        name = name,
+        coords = vec3(center.x, center.y, center.z),
+        radius = radius,
         debug = options.debugPoly,
         options = convert(targetoptions),
         resource = GetInvokingResource(),
@@ -232,6 +250,175 @@ exportHandler('RemoveTargetEntity', function(entities, labels)
             target.removeLocalEntity(entity, labels)
         end
     end
+end)
+
+exportHandler('SpawnPed', function(data)
+	local spawnedped
+	local key, value = next(data)
+	if type(value) == 'table' and type(key) ~= 'string' then
+		for _, v in pairs(data) do
+			if v.spawnNow then
+				lib.requestModel(v.model)
+
+				if type(v.model) == 'string' then v.model = joaat(v.model) end
+
+				if v.minusOne then
+					spawnedped = CreatePed(0, v.model, v.coords.x, v.coords.y, v.coords.z - 1.0, v.coords.w or 0.0, v.networked or false, true)
+				else
+					spawnedped = CreatePed(0, v.model, v.coords.x, v.coords.y, v.coords.z, v.coords.w or 0.0, v.networked or false, true)
+				end
+
+				if v.freeze then
+					FreezeEntityPosition(spawnedped, true)
+				end
+
+				if v.invincible then
+					SetEntityInvincible(spawnedped, true)
+				end
+
+				if v.blockevents then
+					SetBlockingOfNonTemporaryEvents(spawnedped, true)
+				end
+
+				if v.animDict and v.anim then
+					lib.requestAnimDict(v.animDict)
+
+					TaskPlayAnim(spawnedped, v.animDict, v.anim, 8.0, 0, -1, v.flag or 1, 0, false, false, false)
+				end
+
+				if v.scenario then
+					SetPedCanPlayAmbientAnims(spawnedped, true)
+					TaskStartScenarioInPlace(spawnedped, v.scenario, 0, true)
+				end
+
+				if v.pedrelations and type(v.pedrelations.groupname) == 'string' then
+					if type(v.pedrelations.groupname) ~= 'string' then error(v.pedrelations.groupname .. ' is not a string') end
+
+					local pedgrouphash = joaat(v.pedrelations.groupname)
+
+					if not DoesRelationshipGroupExist(pedgrouphash) then
+						AddRelationshipGroup(v.pedrelations.groupname)
+					end
+
+					SetPedRelationshipGroupHash(spawnedped, pedgrouphash)
+					if v.pedrelations.toplayer then
+						SetRelationshipBetweenGroups(v.pedrelations.toplayer, pedgrouphash, joaat('PLAYER'))
+					end
+
+					if v.pedrelations.toowngroup then
+						SetRelationshipBetweenGroups(v.pedrelations.toowngroup, pedgrouphash, pedgrouphash)
+					end
+				end
+
+				if v.weapon then
+					if type(v.weapon.name) == 'string' then v.weapon.name = joaat(v.weapon.name) end
+
+					if IsWeaponValid(v.weapon.name) then
+						SetCanPedEquipWeapon(spawnedped, v.weapon.name, true)
+						GiveWeaponToPed(spawnedped, v.weapon.name, v.weapon.ammo, v.weapon.hidden or false, true)
+						SetPedCurrentWeaponVisible(spawnedped, not v.weapon.hidden or false, true)
+					end
+				end
+
+				if v.target then
+                    local options = v.target
+					if v.target.useModel then
+                        target.addModel(v.model, convert(options))
+					else
+                        target.addLocalEntity(spawnedped, convert(options))
+					end
+				end
+
+				v.currentpednumber = spawnedped
+
+				if v.action then
+					v.action(v)
+				end
+			end
+
+		end
+	else
+		if data.spawnNow then
+			lib.requestModel(data.model)
+
+			if type(data.model) == 'string' then data.model = joaat(data.model) end
+
+			if data.minusOne then
+				spawnedped = CreatePed(0, data.model, data.coords.x, data.coords.y, data.coords.z - 1.0, data.coords.w, data.networked or false, true)
+			else
+				spawnedped = CreatePed(0, data.model, data.coords.x, data.coords.y, data.coords.z, data.coords.w, data.networked or false, true)
+			end
+
+			if data.freeze then
+				FreezeEntityPosition(spawnedped, true)
+			end
+
+			if data.invincible then
+				SetEntityInvincible(spawnedped, true)
+			end
+
+			if data.blockevents then
+				SetBlockingOfNonTemporaryEvents(spawnedped, true)
+			end
+
+			if data.animDict and data.anim then
+				lib.requestAnimDict(data.animDict)
+
+				TaskPlayAnim(spawnedped, data.animDict, data.anim, 8.0, 0, -1, data.flag or 1, 0, false, false, false)
+			end
+
+			if data.scenario then
+				SetPedCanPlayAmbientAnims(spawnedped, true)
+				TaskStartScenarioInPlace(spawnedped, data.scenario, 0, true)
+			end
+
+			if data.pedrelations then
+				if type(data.pedrelations.groupname) ~= 'string' then error(data.pedrelations.groupname .. ' is not a string') end
+
+				local pedgrouphash = joaat(data.pedrelations.groupname)
+
+				if not DoesRelationshipGroupExist(pedgrouphash) then
+					AddRelationshipGroup(data.pedrelations.groupname)
+				end
+
+				SetPedRelationshipGroupHash(spawnedped, pedgrouphash)
+				if data.pedrelations.toplayer then
+					SetRelationshipBetweenGroups(data.pedrelations.toplayer, pedgrouphash, joaat('PLAYER'))
+				end
+
+				if data.pedrelations.toowngroup then
+					SetRelationshipBetweenGroups(data.pedrelations.toowngroup, pedgrouphash, pedgrouphash)
+				end
+			end
+
+			if data.weapon then
+				if type(data.weapon.name) == 'string' then data.weapon.name = joaat(data.weapon.name) end
+
+				if IsWeaponValid(data.weapon.name) then
+					SetCanPedEquipWeapon(spawnedped, data.weapon.name, true)
+					GiveWeaponToPed(spawnedped, data.weapon.name, data.weapon.ammo, data.weapon.hidden or false, true)
+					SetPedCurrentWeaponVisible(spawnedped, not data.weapon.hidden or false, true)
+				end
+			end
+
+			if data.target then
+                local options = data.target
+				if data.target.useModel then
+					target.addModel(data.model, convert(options))
+				else
+					target.addLocalEntity(spawnedped, convert(options))
+				end
+			end
+
+			data.currentpednumber = spawnedped
+			
+			if data.action then
+				data.action(data)
+			end
+		end
+
+		return spawnedped
+	end
 end)
 
 exportHandler('AddTargetModel', function(models, options)

--- a/client/compat/qb-target.lua
+++ b/client/compat/qb-target.lua
@@ -220,7 +220,11 @@ exportHandler('AddTargetBone', function(bones, options)
         v.bones = bones
     end
 
-    exports.ox_target:addGlobalVehicle(options)
+    target.addGlobalVehicle(options)
+end)
+
+exportHandler('RemoveTargetBone', function(bones, labels)
+    target.removeGlobalVehicle(labels)
 end)
 
 exportHandler('AddTargetEntity', function(entities, options)


### PR DESCRIPTION
AddEntityZone and SpawnPed exportHandlers were missing and are been added now in this Commit.

AddEntityZone uses sphere zone to add up zones around the entity differentiating each Entity with a name

Also have added a AddBoxZone Commit if the options.maxZ and options.minZ are nil (missing) then it would return z coord