### PR TITLE
feat: modifiable main/eye icon through exports

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -67,7 +67,7 @@ local function addTarget(target, options, resource)
 
     local num = #target
 
-    for i in ipairs(options) do
+    for i = 1, #options do
         num += 1
         options[i].resource = resource or 'ox_target'
         options[i].mainIcon = mainIcon

--- a/client/api.lua
+++ b/client/api.lua
@@ -47,10 +47,22 @@ local function addTarget(target, options, resource)
         TypeError('options', 'table', optionsType)
     end
 
+    local mainIcon = options.mainIcon
+
+    if mainIcon then
+        options.mainIcon = nil
+        local _options = options
+        options = {}
+
+        for i in pairs(_options) do
+            options[i] = _options[i]
+        end
+    end
+
     local tableType = table.type(options)
 
-    if tableType ~= 'array' and not options.mainIcon then
-        TypeError('options', 'array', ('%s table'):format(tableType))
+    if tableType ~= 'array' then
+        TypeError('options', 'array', ('%s table - only permitted non-number/string key index is "mainIcon"'):format(tableType))
     end
 
     local num = #target
@@ -58,7 +70,7 @@ local function addTarget(target, options, resource)
     for i in ipairs(options) do
         num += 1
         options[i].resource = resource or 'ox_target'
-        options[i].mainIcon = options.mainIcon
+        options[i].mainIcon = mainIcon
         target[num] = options[i]
     end
 end

--- a/client/api.lua
+++ b/client/api.lua
@@ -49,15 +49,16 @@ local function addTarget(target, options, resource)
 
     local tableType = table.type(options)
 
-    if tableType ~= 'array' then
+    if tableType ~= 'array' and not options.mainIcon then
         TypeError('options', 'array', ('%s table'):format(tableType))
     end
 
     local num = #target
 
-    for i = 1, #options do
+    for i in ipairs(options) do
         num += 1
         options[i].resource = resource or 'ox_target'
+        options[i].mainIcon = options.mainIcon
         target[num] = options[i]
     end
 end

--- a/client/api.lua
+++ b/client/api.lua
@@ -47,10 +47,10 @@ local function addTarget(target, options, resource)
         TypeError('options', 'table', optionsType)
     end
 
-    local mainIcon = options.mainIcon
+    local mainIcon, mainIconColor = options.mainIcon, options.mainIconColor
 
-    if mainIcon then
-        options.mainIcon = nil
+    if mainIcon or mainIconColor then
+        options.mainIcon, options.mainIconColor = nil, nil
         local _options = options
         options = {}
 
@@ -62,7 +62,7 @@ local function addTarget(target, options, resource)
     local tableType = table.type(options)
 
     if tableType ~= 'array' then
-        TypeError('options', 'array', ('%s table - only permitted non-number/string key index is "mainIcon"'):format(tableType))
+        TypeError('options', 'array', ('%s table - only permitted non-number/string key index is "mainIcon" & "mainIconColor"'):format(tableType))
     end
 
     local num = #target
@@ -71,6 +71,7 @@ local function addTarget(target, options, resource)
         num += 1
         options[i].resource = resource or 'ox_target'
         options[i].mainIcon = mainIcon
+        options[i].mainIconColor = mainIconColor
         target[num] = options[i]
     end
 end

--- a/client/defaults.lua
+++ b/client/defaults.lua
@@ -38,6 +38,7 @@ ox_target:addGlobalVehicle({
 
 ox_target:addGlobalVehicle({
     mainIcon = 'fa-solid fa-info',
+    mainIconColor = '#f21505',
     {
         name = 'ox_target:passengerF',
         icon = 'fa-solid fa-car-side',

--- a/client/defaults.lua
+++ b/client/defaults.lua
@@ -37,6 +37,7 @@ ox_target:addGlobalVehicle({
 })
 
 ox_target:addGlobalVehicle({
+    mainIcon = 'fa-solid fa-info',
     {
         name = 'ox_target:passengerF',
         icon = 'fa-solid fa-car-side',
@@ -79,6 +80,7 @@ ox_target:addGlobalVehicle({
 })
 
 ox_target:addGlobalVehicle({
+    mainIcon = 'fa-solid fa-car',
     {
         name = 'ox_target:passengerR',
         icon = 'fa-solid fa-car-side',
@@ -117,6 +119,7 @@ ox_target:addGlobalVehicle({
 })
 
 ox_target:addGlobalVehicle({
+    mainIcon = 'fa-solid fa-car',
     {
         name = 'ox_target:trunk',
         icon = 'fa-solid fa-car-rear',

--- a/client/defaults.lua
+++ b/client/defaults.lua
@@ -16,6 +16,7 @@ local function toggleDoor(vehicle, door)
 end
 
 ox_target:addGlobalVehicle({
+    mainIcon = 'fa-solid fa-car',
     {
         name = 'ox_target:driverF',
         icon = 'fa-solid fa-car-side',
@@ -37,8 +38,7 @@ ox_target:addGlobalVehicle({
 })
 
 ox_target:addGlobalVehicle({
-    mainIcon = 'fa-solid fa-info',
-    mainIconColor = '#f21505',
+    mainIcon = 'fa-solid fa-car',
     {
         name = 'ox_target:passengerF',
         icon = 'fa-solid fa-car-side',
@@ -60,6 +60,7 @@ ox_target:addGlobalVehicle({
 })
 
 ox_target:addGlobalVehicle({
+    mainIcon = 'fa-solid fa-car',
     {
         name = 'ox_target:driverR',
         icon = 'fa-solid fa-car-side',
@@ -104,6 +105,7 @@ ox_target:addGlobalVehicle({
 
 
 ox_target:addGlobalVehicle({
+    mainIcon = 'fa-solid fa-car',
     {
         name = 'ox_target:bonnet',
         icon = 'fa-solid fa-car',

--- a/client/main.lua
+++ b/client/main.lua
@@ -52,6 +52,7 @@ local function enableTargeting()
     local getNearbyZones, drawSprites = DrawSprites()
 
     while isActive do
+        local mainIcon
         local playerCoords = GetEntityCoords(cache.ped)
         hit, entityHit, endCoords = RaycastFromCamera(flag)
         entityType = entityHit ~= 0 and GetEntityType(entityHit) or 0
@@ -200,7 +201,7 @@ local function enableTargeting()
 
                     v[i].hide = hide
 
-                    if hide then hidden += 1 end
+                    if hide then hidden += 1 elseif not mainIcon then mainIcon = option.mainIcon end
                 end
             end
 
@@ -212,6 +213,7 @@ local function enableTargeting()
                 else
                     SendNuiMessage(json.encode({
                         event = 'setTarget',
+                        icon = mainIcon,
                         options = options
                     }, { sort_keys=true }))
                 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -210,6 +210,9 @@ local function enableTargeting()
                 end
             end
 
+            mainIcon = mainIcon or currentZone?.mainIcon
+            mainIconColor = mainIconColor or currentZone?.mainIconColor
+
             if newOptions and next(newOptions) then
                 options = newOptions
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -52,7 +52,7 @@ local function enableTargeting()
     local getNearbyZones, drawSprites = DrawSprites()
 
     while isActive do
-        local mainIcon
+        local mainIcon, mainIconColor
         local playerCoords = GetEntityCoords(cache.ped)
         hit, entityHit, endCoords = RaycastFromCamera(flag)
         entityType = entityHit ~= 0 and GetEntityType(entityHit) or 0
@@ -201,7 +201,12 @@ local function enableTargeting()
 
                     v[i].hide = hide
 
-                    if hide then hidden += 1 elseif not mainIcon then mainIcon = option.mainIcon end
+                    if hide then
+                        hidden += 1
+                    else
+                        mainIcon = mainIcon or option.mainIcon
+                        mainIconColor = mainIconColor or option.mainIconColor
+                    end
                 end
             end
 
@@ -213,7 +218,8 @@ local function enableTargeting()
                 else
                     SendNuiMessage(json.encode({
                         event = 'setTarget',
-                        icon = mainIcon,
+                        mainIcon = mainIcon,
+                        mainIconColor = mainIconColor,
                         options = options
                     }, { sort_keys=true }))
                 end

--- a/web/index.html
+++ b/web/index.html
@@ -1,13 +1,14 @@
 <html>
   <head>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css" />
-    <link href="style.css" rel="stylesheet" type="text/css" />
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css' />
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200' />
+    <link href='style.css' rel='stylesheet' type='text/css' />
   </head>
   <body>
-    <div id="eye">
-      <i id="eyeSvg" class="fa-fw" style="height: 36px; width: 36px; color: #000000;"></i>
+    <div id='eye'>
+      <i id='eyeSvg' style='height: 36px; width: 36px; color: #000000;'></i>
     </div>
-    <div id="options-wrapper"></div>
-    <script defer type="module" src="js/main.js"></script>
+    <div id='options-wrapper'></div>
+    <script defer type='module' src='js/main.js'></script>
   </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div id="eye">
-      <svg id="eyeSvg" xmlns="http://www.w3.org/2000/svg" height="36px" viewBox="0 0 24 24" width="36px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 4C7 4 2.73 7.11 1 11.5 2.73 15.89 7 19 12 19s9.27-3.11 11-7.5C21.27 7.11 17 4 12 4zm0 12.5c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/></svg>
+      <i id="eyeSvg" class="fa-fw" style="height: 36px; width: 36px; color: #000000;"></i>
     </div>
     <div id="options-wrapper"></div>
     <script defer type="module" src="js/main.js"></script>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -3,22 +3,38 @@ import { createOptions } from './createOptions.js';
 const optionsWrapper = document.getElementById('options-wrapper');
 const body = document.body;
 const eye = document.getElementById('eyeSvg');
+const defaultIcon = "fa-solid fa-eye";
+let currentIcon;
 
 window.addEventListener('message', (event) => {
   optionsWrapper.innerHTML = '';
 
+  if (!currentIcon || currentIcon !== defaultIcon) {
+    if (currentIcon) {
+      eye.classList.remove(currentIcon);
+    }
+
+    eye.classList.add(defaultIcon);
+    currentIcon = defaultIcon;
+  }
+  
   switch (event.data.event) {
     case 'visible': {
       body.style.visibility = event.data.state ? 'visible' : 'hidden';
-      return (eye.style.fill = 'black');
+      return (eye.style.color = 'black');
     }
 
     case 'leftTarget': {
-      return (eye.style.fill = 'black');
+      return (eye.style.color = 'black');
     }
 
     case 'setTarget': {
-      eye.style.fill = '#cfd2da';
+      if (event.data.icon) {
+        eye.classList.add(event.data.icon);
+        currentIcon = event.data.icon;
+      }
+
+      eye.style.color = '#cfd2da';
 
       if (event.data.options) {
         for (const type in event.data.options) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -3,20 +3,20 @@ import { createOptions } from './createOptions.js';
 const optionsWrapper = document.getElementById('options-wrapper');
 const body = document.body;
 const eye = document.getElementById('eyeSvg');
-const defaultIcon = "fa-solid fa-eye";
+const defaultIcon = 'fa-solid fa-eye';
 let currentIcon;
 
 const addEyeIcon = function (newIcon = defaultIcon) {
   if (!currentIcon || newIcon !== currentIcon) {
     if (currentIcon) {
-      const previousIconData = currentIcon.split(" ");
+      const previousIconData = currentIcon.split(' ');
 
       for (let i = 0; i < previousIconData.length; i++) {
         eye.classList.remove(previousIconData[i]);
       }
     }
     
-    const newIconData = newIcon.split(" ");
+    const newIconData = newIcon.split(' ');
 
     for (let i = 0; i < newIconData.length; i++) {
       eye.classList.add(newIconData[i]);

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -6,7 +6,7 @@ const eye = document.getElementById('eyeSvg');
 const defaultIcon = 'fa-solid fa-eye';
 let currentIcon;
 
-const addEyeIcon = function (newIcon = defaultIcon) {
+const setMainIcon = function (newIcon = defaultIcon) {
   if (!currentIcon || newIcon !== currentIcon) {
     if (currentIcon) {
       const previousIconData = currentIcon.split(' ');
@@ -26,27 +26,28 @@ const addEyeIcon = function (newIcon = defaultIcon) {
   }
 };
 
+const setMainIconColor = function (newIconColor) {
+  eye.style.color = newIconColor
+};
+
 window.addEventListener('message', (event) => {
   optionsWrapper.innerHTML = '';
 
-  addEyeIcon(defaultIcon);
+  setMainIcon(defaultIcon);
   
   switch (event.data.event) {
     case 'visible': {
       body.style.visibility = event.data.state ? 'visible' : 'hidden';
-      return (eye.style.color = 'black');
+      return setMainIconColor('black');
     }
 
     case 'leftTarget': {
-      return (eye.style.color = 'black');
+      return setMainIconColor('black');
     }
 
     case 'setTarget': {
-      if (event.data.icon) {
-        addEyeIcon(event.data.icon);
-      }
-
-      eye.style.color = '#cfd2da';
+      setMainIcon(event.data.icon);
+      setMainIconColor(event.data.mainIconColor || '#cfd2da');
 
       if (event.data.options) {
         for (const type in event.data.options) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -6,17 +6,30 @@ const eye = document.getElementById('eyeSvg');
 const defaultIcon = "fa-solid fa-eye";
 let currentIcon;
 
+const addEyeIcon = function (newIcon = defaultIcon) {
+  if (!currentIcon || newIcon !== currentIcon) {
+    if (currentIcon) {
+      const previousIconData = currentIcon.split(" ");
+
+      for (let i = 0; i < previousIconData.length; i++) {
+        eye.classList.remove(previousIconData[i]);
+      }
+    }
+    
+    const newIconData = newIcon.split(" ");
+
+    for (let i = 0; i < newIconData.length; i++) {
+      eye.classList.add(newIconData[i]);
+    }
+
+    currentIcon = newIcon;
+  }
+};
+
 window.addEventListener('message', (event) => {
   optionsWrapper.innerHTML = '';
 
-  if (!currentIcon || currentIcon !== defaultIcon) {
-    if (currentIcon) {
-      eye.classList.remove(currentIcon);
-    }
-
-    eye.classList.add(defaultIcon);
-    currentIcon = defaultIcon;
-  }
+  addEyeIcon(defaultIcon);
   
   switch (event.data.event) {
     case 'visible': {
@@ -30,8 +43,7 @@ window.addEventListener('message', (event) => {
 
     case 'setTarget': {
       if (event.data.icon) {
-        eye.classList.add(event.data.icon);
-        currentIcon = event.data.icon;
+        addEyeIcon(event.data.icon);
       }
 
       eye.style.color = '#cfd2da';

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -46,7 +46,7 @@ window.addEventListener('message', (event) => {
     }
 
     case 'setTarget': {
-      setMainIcon(event.data.icon);
+      setMainIcon(event.data.mainIcon);
       setMainIconColor(event.data.mainIconColor || '#cfd2da');
 
       if (event.data.options) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -3,38 +3,44 @@ import { createOptions } from './createOptions.js';
 const optionsWrapper = document.getElementById('options-wrapper');
 const body = document.body;
 const eye = document.getElementById('eyeSvg');
-const defaultIcon = 'fa-solid fa-eye';
+const defaultIconFontAwesome = 'fa-solid fa-eye';
+const defaultIconGoogleMaterial = 'visibility';
+const googleMaterialClass = 'material-symbols-outlined';
+const defaultIconAsGoogleMaterial = true; //whether the default icon should use google material or font awesome
 let currentIcon;
 
-const setMainIcon = function (newIcon = defaultIcon) {
+const setMainIcon = function (newIcon = defaultIconAsGoogleMaterial ? defaultIconGoogleMaterial : defaultIconFontAwesome) {
   if (!currentIcon || newIcon !== currentIcon) {
     if (currentIcon) {
-      const previousIconData = currentIcon.split(' ');
+      const previousIconData = (currentIcon === defaultIconGoogleMaterial ? googleMaterialClass : currentIcon).split(' ');
 
       for (let i = 0; i < previousIconData.length; i++) {
         eye.classList.remove(previousIconData[i]);
       }
     }
-    
-    const newIconData = newIcon.split(' ');
+
+    const isNewIconGoogleMaterial = newIcon === defaultIconGoogleMaterial;
+    const newIconData = (isNewIconGoogleMaterial ? googleMaterialClass : newIcon).split(' ');
 
     for (let i = 0; i < newIconData.length; i++) {
       eye.classList.add(newIconData[i]);
     }
+
+    eye.textContent = isNewIconGoogleMaterial ? defaultIconGoogleMaterial : '';
 
     currentIcon = newIcon;
   }
 };
 
 const setMainIconColor = function (newIconColor) {
-  eye.style.color = newIconColor
+  eye.style.color = eye.style.fill = newIconColor;
 };
 
 window.addEventListener('message', (event) => {
   optionsWrapper.innerHTML = '';
 
-  setMainIcon(defaultIcon);
-  
+  setMainIcon();
+
   switch (event.data.event) {
     case 'visible': {
       body.style.visibility = event.data.state ? 'visible' : 'hidden';

--- a/web/style.css
+++ b/web/style.css
@@ -14,7 +14,11 @@ p {
 }
 
 .material-symbols-outlined {
-  font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 40;
+  font-variation-settings:
+    'FILL' 1,
+    'wght' 400,
+    'GRAD' 200,
+    'opsz' 48
 }
 
 #eye {


### PR DESCRIPTION
Preview: https://youtu.be/Sat_JFo1sQ0

Note: once 3rd eye is active and there are multiple main icons set through exports, it uses the top/highest customizable icon from the target options index that is not hidden(based on `canInteract` property and etc)

Example usage for global and entity exports:
```lua
ox_target:addGlobalVehicle({
    mainIcon = 'fa-brands fa-internet-explorer',
    mainIconColor = '#eb0546',
    {
        name = ...,
        icon = ...,
        label = ...,
        bones = ...,
        canInteract = ...,
        onSelect = ...
    }
})
```

Example usage for zone exports:
```lua
ox_target:addBoxZone({
    mainIcon = 'fa-brands fa-internet-explorer',
    mainIconColor = '#eb0546',
    coords = ...
    size = ...,
    rotation = ...,
    debug = ...,
    drawSprite = ...,
    options = ...
})
```