### PR TITLE
Add submenus to ox_target

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -379,7 +379,7 @@ RegisterNUICallback('select', function(data, cb)
             ExecuteCommand(option.command)
         end
         
-        if option.openMenu then
+        if option.openMenu ~= currentMenu then
             currentMenu = option.openMenu
             state.setNuiFocus(true, true, false)
             forceNuiActive = true

--- a/client/state.lua
+++ b/client/state.lua
@@ -24,8 +24,9 @@ function state.isNuiFocused()
 end
 
 ---@param value boolean
-function state.setNuiFocus(value, cursor)
-    if value then SetCursorLocation(0.5, 0.5) end
+function state.setNuiFocus(value, cursor, reset)
+    reset = reset ~= false
+    if value and reset then SetCursorLocation(0.5, 0.5) end
 
     nuiFocus = value
     SetNuiFocus(value, cursor or false)


### PR DESCRIPTION
This pull request/documentation update introduces a new feature to ox_target. Users can now add submenus to the existing functionality.

Here's how it works:
To enable submenus, two new variables have been added: menuName and openMenu.

1. menuName: This variable allows you to assign a name to a 'menu'. It functions similarly to the ID field for different items, but in this case, it groups various items together under a specific menu. Additionally, you can combine items from different scripts as long as they share the same menu name.
2. openMenu: This variable is used to specify the menu you want to open. If you wish to return to the 'homescreen', you can use the menu name 'home' here. We explored different options, and this implementation was chosen for its simplicity and cleanliness.

By incorporating these changes, users will have the ability to enhance the functionality of ox_target by organizing related items into submenus.

To enhance the cleanliness of the menu system, several changes have been made to the backend. One of these changes affects the callback function for item selection. I have modified it so that when you select an item with a submenu attached, you can continue navigating the menu without having to re-enable NUI. This adjustment ensures a smoother user experience and prevents the pointer from returning to the previous position. To achieve this, I have added a reset parameter to the state.setNuiFocus function in the state.lua file.

Additionally, when canceling the target system, the menus will now reset to the standard 'home' setting. This change prevents users from being stuck in a submenu or needing to click the 'back' button repeatedly.

If you have any questions or need further clarification, please don't hesitate to reach out to me. 
You can contact me here or through Discord at "vitalpulse".