### PR TITLE
chore: disable interacting with doors if ped is in any vehicle

### DIFF
--- a/client/defaults.lua
+++ b/client/defaults.lua
@@ -30,7 +30,7 @@ end
 ---@param useOffset boolean?
 ---@return boolean?
 local function canInteractWithDoor(entity, coords, door, useOffset)
-    if not GetIsDoorValid(entity, door) or GetVehicleDoorLockStatus(entity) > 1 or IsVehicleDoorDamaged(entity, door) then return end
+    if not GetIsDoorValid(entity, door) or GetVehicleDoorLockStatus(entity) > 1 or IsVehicleDoorDamaged(entity, door) or IsPedInAnyVehicle(PlayerPedId(), false) then return end
 
     if useOffset then return true end
 

--- a/client/defaults.lua
+++ b/client/defaults.lua
@@ -30,7 +30,7 @@ end
 ---@param useOffset boolean?
 ---@return boolean?
 local function canInteractWithDoor(entity, coords, door, useOffset)
-    if not GetIsDoorValid(entity, door) or GetVehicleDoorLockStatus(entity) > 1 or IsVehicleDoorDamaged(entity, door) or IsPedInAnyVehicle(PlayerPedId(), false) then return end
+    if not GetIsDoorValid(entity, door) or GetVehicleDoorLockStatus(entity) > 1 or IsVehicleDoorDamaged(entity, door) or cache.vehicle then return end
 
     if useOffset then return true end
 


### PR DESCRIPTION
Hey,

we'r about to use ox_target on our Server and i'd like to use those defaults for simple vehicle interactions. We just found out, that you can interact with other vehicles even if your driving/sitting in yet another vehicle. I think this is not the desired behaviour and therefore should be changed.

If this change will not be merged, its fine by us, we will probably just copy the implementation, deactive the defaults and add those restriction on our own. But we think, everyone using the default should profit from this change, as it improves the immersivity. ☺️ 

Have a greate day,
SeaLife