### PR TITLE
fix(client): check for fake resource exports

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -120,6 +120,10 @@ end
 function utils.hasExport(export)
     local resource, exportName = string.strsplit('.', export)
 
+    if GetResourceState(resource) ~= 'started' then
+        return false
+    end
+
     return pcall(function()
         return exports[resource][exportName]
     end)


### PR DESCRIPTION
We only want to check real resource exports, not fake ones. This commit fixes compatibility issues with inventory scripts that are faking the 'ox_inventory.Items' export.