### PR TITLE
fix(client/api): `name` parameter on `removeZone`

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -91,7 +91,7 @@ function api.removeZone(id, suppressWarning)
             local foundZone
 
             for _, v in pairs(Zones) do
-                if v.name == id then
+                if v.options[1].name == id then
                     foundZone = true
                     v:remove()
                 end


### PR DESCRIPTION
The `name` parameter is part of the `options` table, not the root zone table.