### PR TITLE
fix(client): recreate offset vector

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -107,7 +107,7 @@ local function shouldHide(option, distance, endCoords, entityHit, entityType, en
 
         if not option.absoluteOffset then
             local min, max = GetModelDimensions(entityModel)
-            offset = (max - min) * offset + min
+            offset = (max - min) * vec3(offset.x, offset.y, offset.z) + min
         end
 
         offset = GetOffsetFromEntityInWorldCoords(entityHit, offset.x, offset.y, offset.z)


### PR DESCRIPTION
Fixes the following error when using `offset` option in JS:

![image](https://github.com/user-attachments/assets/79ac6c7e-81ba-437e-9dea-c9650579548c)