### PR TITLE
fix(client): Sprite Distance Check

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -108,6 +108,10 @@ function utils.drawZoneSprites(dict, texture)
         local spriteColour = zone.colour or colour
 
         if zone.drawSprite ~= false then
+            -- This is a stupid dist check because of weird sprite popups
+            local dist = #(GetEntityCoords(cache.ped) - zone.coords.xyz)
+            if dist >= zone.distance or 2.5 then return end
+
             SetDrawOrigin(zone.coords.x, zone.coords.y, zone.coords.z)
             DrawSprite(dict, texture, 0, 0, width, height, 0, spriteColour.r, spriteColour.g, spriteColour.b,
                 spriteColour.a)


### PR DESCRIPTION
This is a stupid check because of some weird sprites being drawn way outside of the distance field. Had this issue pop up for me recently and thought to push this as a way to help others if it