### PR TITLE
ref(client): remove unused functions

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -69,20 +69,6 @@ function api.addSphereZone(data)
     return lib.zones.sphere(data).id
 end
 
----@param id number | string The ID of the zone to check. It can be either a number or a string representing the zone's index or name, respectively.
----@return boolean returns true if the zone with the specified ID exists, otherwise false.
-function api.zoneExists(id)
-    if not Zones or (type(id) ~= 'number' and type(id) ~= 'string') then return false end
-
-    if type(id) == 'number' and Zones[id] then return true end
-
-    for _, zone in pairs(lib.zones.getAllZones()) do
-        if type(id) == 'string' and zone.name == id then return true end
-    end
-
-    return false
-end
-
 ---@param id number | string
 ---@param suppressWarning boolean?
 function api.removeZone(id, suppressWarning)

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -1,33 +1,5 @@
 local utils = {}
 
-local GetWorldCoordFromScreenCoord = GetWorldCoordFromScreenCoord
-local StartShapeTestLosProbe = StartShapeTestLosProbe
-local GetShapeTestResultIncludingMaterial = GetShapeTestResultIncludingMaterial
-
----@param flag number
----@return boolean hit
----@return number entityHit
----@return vector3 endCoords
----@return vector3 surfaceNormal
----@return number materialHash
-function utils.raycastFromCamera(flag)
-    local coords, normal = GetWorldCoordFromScreenCoord(0.5, 0.5)
-    local destination = coords + normal * 10
-    local handle = StartShapeTestLosProbe(coords.x, coords.y, coords.z, destination.x, destination.y, destination.z,
-        flag, cache.ped, 4)
-
-    while true do
-        Wait(0)
-        local retval, hit, endCoords, surfaceNormal, materialHash, entityHit = GetShapeTestResultIncludingMaterial(
-        handle)
-
-        if retval ~= 1 then
-            ---@diagnostic disable-next-line: return-type-mismatch
-            return hit, entityHit, endCoords, surfaceNormal, materialHash
-        end
-    end
-end
-
 function utils.getTexture()
     return lib.requestStreamedTextureDict('shared'), 'emptydot_32'
 end


### PR DESCRIPTION
These functions aren't used anywhere and aren't exported so we don't need them.