### PR TITLE
fix(client/utils): Fix sprites not showing correctly

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -47,6 +47,7 @@ local width = 0.02
 local height = width * GetAspectRatio(false)
 
 if drawZoneSprites == 0 then drawZoneSprites = -1 end
+if drawZoneSprites == 1 then drawZoneSprites = 24 end
 
 ---@param coords vector3
 ---@return CZone[], boolean


### PR DESCRIPTION
Currently, ox_target limits the number of sprites being drawn per-frame using the literal value of the `ox_target:drawSprite` Convar. This is misleading, as the docs indicate the convar is simply used to toggle the drawing on/off, but what it's actually doing is limiting the number of sprites that can be drawn per frame, here:

https://github.com/overextended/ox_target/blob/6ee2b5a60e8e4341ca4ddd645e308365e8e9160b/client/utils.lua#L36

https://github.com/overextended/ox_target/blob/6ee2b5a60e8e4341ca4ddd645e308365e8e9160b/client/utils.lua#L70

This is because we set the value of `drawZoneSprites` to be the exact value of the Convar, meaning if you set the convar to be `1`, you end up with an odd behaviour where some sprites within range of other sprites will never show at the same time. See repro in video(s) below:

https://discord.com/channels/813030955598086174/1358472533409534255/1358474412336091187

https://discord.com/channels/813030955598086174/1358472533409534255/1358474678913470645

Looking at the default value for the convar when no value is set, it assumes a value of 24, so it stands to reason that if the convar is set to 1, we should probably set `drawZoneSprites` to be 24.