### PR TITLE
fix(client): remove the global options added by a script when it is s…

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -376,6 +376,19 @@ CreateThread(function()
     end
 end)
 
+---@type OxTargetOption[]
+local global = {}
+
+---@param options OxTargetOption | OxTargetOption[]
+function api.addGlobalOption(options)
+    addTarget(global, options, GetInvokingResource())
+end
+
+---@param options string | string[]
+function api.removeGlobalOption(options)
+    removeTarget(global, options, GetInvokingResource())
+end
+
 ---@param resource string
 ---@param target table
 local function removeResourceGlobals(resource, target)
@@ -412,7 +425,7 @@ end
 
 ---@param resource string
 AddEventHandler('onClientResourceStop', function(resource)
-    removeResourceGlobals(resource, { peds, vehicles, objects, players })
+    removeResourceGlobals(resource, { peds, vehicles, objects, players, global })
     removeResourceTargets(resource, { models, entities, localEntities })
 
     if Zones then
@@ -469,19 +482,6 @@ function options_mt:set(entity, _type, model)
     if self.model then options_mt.size += 1 end
     if self.entity then options_mt.size += 1 end
     if self.localEntity then options_mt.size += 1 end
-end
-
----@type OxTargetOption[]
-local global = {}
-
----@param options OxTargetOption | OxTargetOption[]
-function api.addGlobalOption(options)
-    addTarget(global, options, GetInvokingResource())
-end
-
----@param options string | string[]
-function api.removeGlobalOption(options)
-    removeTarget(global, options, GetInvokingResource())
 end
 
 ---@class OxTargetOptions


### PR DESCRIPTION
Hi, we noticed some performance issues when adding global options in our own script:
Specifically, the resource usage (observed by the resource monitor) keeps increasing after every restart of the invoking script.
After some investigation, we found that the global options added by an external script are not removed in ox_target when it is stopped.

This pull request properly removes global options added by scripts when they are stopped.
We had to move the definition of the `global` variable and related api functions before the `removeResourceGlobals` function that is called in the `onClientResourceStop` event handler so we can access the variable.